### PR TITLE
Remove tags when deselected from the select box

### DIFF
--- a/specs/html-templates/master-template/js/main.js
+++ b/specs/html-templates/master-template/js/main.js
@@ -1,5 +1,5 @@
 // JAVASCRIPT CUSTOM
-      
+
 //toggle plus,minus icons for sidebar accordion headers
 $('.collapse').on('shown.bs.collapse', function(){
     $(this).parent().find(".glyphicon-plus").removeClass("glyphicon-plus").addClass("glyphicon-minus");
@@ -39,9 +39,9 @@ $('#search-sidebar').keyup(function(){
         });
         output += '</div>';
         $('#results').html(output);
-    }); 
+    });
     if (searchField == "") {
-        
+
         $("#results").css("display", "none");
         $(".search").css("padding-bottom",7);
     }
@@ -113,20 +113,16 @@ $('.product-slider').slick({
 })
 })
 
-$(".selectpicker").change(function() {
-    var val = $('option', this).filter(':selected:last').val();
-    var lastSelected = $('.selectpicker option').index($('.selectpicker option:selected'))
-    console.log("last selected " + lastSelected);
-        var htm = '';
-        htm = '<li><label class="alert alert-warning alert-dismissible fade in" role="alert"> <button type="button" class="close" data-dismiss="alert" aria-label="Close" data-id="' + val + '"<span aria-hidden="true">×</span></button> <strong>' + val + '</strong></label></li>';
-        
-        $('.selectpicker-items-selected').append(htm);
-        $('.selectpicker-items-selected').selectpicker('render');
-})
-$('.selectpicker').selectpicker({
-  noneSelectedText: 'Select one or more content pieces'
+$(".selectpicker").on('changed.bs.select', function (e, clickedIndex, newValue, oldValue) {
+  var val = e.target[clickedIndex].text;
+  if (newValue == true) {
+    var htm = '<li id="items-selected-' + clickedIndex + '"><label class="alert alert-warning alert-dismissible fade in" role="alert"> <button type="button" class="close" data-dismiss="alert" aria-label="Close" data-id="' + val + '"<span aria-hidden="true">×</span></button> <strong>' + val + '</strong></label></li>';
+    $('.selectpicker-items-selected').append(htm);
+    $('.selectpicker-items-selected').selectpicker('render');
+  } else {
+    $('#items-selected-' + clickedIndex).remove();
+  }
 });
-
 
 $('.close').click(function () {
   $('.selectpicker').selectpicker('refresh');

--- a/specs/html-templates/master-template/template-master-5-7-cols.html
+++ b/specs/html-templates/master-template/template-master-5-7-cols.html
@@ -108,7 +108,7 @@
               <!-- /form -->
               <form>
                 <div class="btn-group bootstrap-select">
-                <select class="selectpicker form-control" multiple data-selected-text-format="count > 3" data-actions-box="false" data-style="white-button">
+                <select class="selectpicker form-control" title="Select one or more content pieces" multiple data-selected-text-format="count > 3" data-actions-box="false" data-style="white-button">
                   <option data-select-id="Content Item">Content Item</option>
                   <option data-select-id="Longer Content Item">Longer Content Item</option>
                   <option data-select-id="Content Item 2">Content Item 2</option>
@@ -118,7 +118,7 @@
                 </select>
                 </div>
                 <ul class="list-inline selectpicker-items-selected">
-                  
+
                   </ul>
               </form>
             </div>
@@ -126,12 +126,12 @@
         </div>
       </div>
     </aside>
-      
+
     <!-- body -->
     <div class="col-sm-12 col-lg-7">
         <div class="row pad-title-align-to-sidebar">
           <div class="col-lg-12" style="width:100%; background-color:#e6e7e8; height:100%;">
-            
+
       </div><!-- ./row -->
       </div></div></main>
   <div class="container">
@@ -153,7 +153,7 @@
 
   <script src="js/main.js"></script>
 
- 
+
 </body>
 
 </html>


### PR DESCRIPTION
This uses the `changed.bs.select` event to determine whether a tag should be added or removed to the 
`.selectpicker-items-selected` list.

@blueflymedia I think this gets you pretty close to what you want. If you need to deselect the appropriate selectbox item when the tag is removed, you'll have to listen for the `closed.bs.alert` event and remove the parent `li` tag as well as deselect the corresponding option in the select list.
